### PR TITLE
fix(api): 在 dify 代理路由处理程序中 await params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# dummy files
-files/*
+# test files
+/files

--- a/app/api/dify/[appId]/[...slug]/route.ts
+++ b/app/api/dify/[appId]/[...slug]/route.ts
@@ -28,9 +28,12 @@ function createMinimalHeaders(contentType?: string): Headers {
 // --- 核心辅助函数：执行到 Dify 的代理请求 ---
 async function proxyToDify(
   req: NextRequest, // 原始 Next.js 请求对象
-  { params }: { params: DifyApiParams } // 直接解构 params
+  // 修改点 1：接收包含 params 的 context 对象
+  context: { params: Promise<DifyApiParams> | DifyApiParams } // 允许 Promise 或直接对象以兼容不同 Next.js 版本或场景
 ) {
-  // 等待 params 解析完成后再访问其属性
+
+  // 修改点 2：使用 await 获取 params 的值
+  const params = await context.params;
   const appId = params.appId;
   const slug = params.slug;
 
@@ -140,7 +143,7 @@ async function proxyToDify(
             headersToForward.set(key, value);
          }
       });
-      // 添加 CORS 响应头 (根据需要调整源)
+      // 添加 CORS 响应头 (生产环境应配置更严格的源)
       headersToForward.set('Access-Control-Allow-Origin', '*'); 
       headersToForward.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
       headersToForward.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');


### PR DESCRIPTION
调整 Dify API 代理路由处理程序 (`app/api/dify/[appId]/[...slug]/route.ts`) 以适应 Next.js 向异步动态 API 迁移的趋势。

具体而言，此提交修改了 `proxyToDify` 函数，在访问 `appId` 和 `slug` 之前先 `await context.params`，解决了"params should be awaited before using its properties"的警告，并确保了与未来 Next.js 版本的兼容性，因为直接同步访问将被弃用。

同时也包含了 `.gitignore` 中一些小的相关改动。