### PR TITLE
File upload

### DIFF
--- a/app/chat/[conversationId]/page.tsx
+++ b/app/chat/[conversationId]/page.tsx
@@ -10,10 +10,13 @@ import {
   PromptContainer, 
   ScrollToBottomButton
 } from '@components/chat';
+import { FilePreviewCanvas } from '@components/file-preview/file-preview-canvas';
 import { useChatInterface, useChatStateSync } from '@lib/hooks';
 import { useChatStore } from '@lib/stores/chat-store';
 import { useChatLayoutStore } from '@lib/stores/chat-layout-store';
 import { useChatScroll } from '@lib/hooks/use-chat-scroll';
+import { useFilePreviewStore } from '@lib/stores/ui/file-preview-store';
+import { cn } from '@lib/utils';
 
 export default function ChatPage() {
   const params = useParams();
@@ -21,6 +24,7 @@ export default function ChatPage() {
   
   const setCurrentConversationId = useChatStore((state) => state.setCurrentConversationId);
   const { inputHeight } = useChatLayoutStore();
+  const isPreviewOpen = useFilePreviewStore((state) => state.isPreviewOpen);
 
   const { isDark, isWelcomeScreen } = useChatStateSync();
   
@@ -53,10 +57,19 @@ export default function ChatPage() {
 
   return (
     <div 
-      className={`h-full flex flex-col ${isDark ? "bg-gray-900 text-white" : "bg-gray-50 text-gray-900"}`}
-      style={{ '--chat-input-height': chatInputHeightVar } as React.CSSProperties}
+      className={cn(
+        "h-full flex",
+        isDark ? "bg-gray-900 text-white" : "bg-gray-50 text-gray-900"
+      )}
     >
-      <div className="relative h-full flex flex-col overflow-hidden">
+      <div 
+        className={cn(
+          "relative h-full flex flex-col overflow-hidden",
+          "transition-[width] duration-300 ease-in-out",
+          isPreviewOpen ? "w-[50%] lg:w-[60%]" : "w-full"
+        )}
+        style={{ '--chat-input-height': chatInputHeightVar } as React.CSSProperties}
+      >
         <div className="flex-1 overflow-hidden">
           {isWelcomeScreen && useChatStore.getState().currentConversationId === null ? (
             <WelcomeScreen />
@@ -87,6 +100,8 @@ export default function ChatPage() {
         
         {useChatStore.getState().currentConversationId === null && <PromptContainer />}
       </div>
+      
+      <FilePreviewCanvas /> 
     </div>
   );
 } 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { TooltipContainer } from "@components/ui/tooltip";
 import "./globals.css";
+import { NotificationBar } from '@components/ui/notification-bar';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,12 +25,13 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
         <TooltipContainer />
+        <NotificationBar />
       </body>
     </html>
   );

--- a/components/chat-input/attachment-preview-bar.tsx
+++ b/components/chat-input/attachment-preview-bar.tsx
@@ -11,12 +11,13 @@ import { AttachmentPreviewItem } from "./attachment-preview-item"
 interface AttachmentPreviewBarProps {
   isDark?: boolean
   onHeightChange: (height: number) => void // 回调函数，通知父组件高度变化
+  onRetryUpload: (id: string) => void // 添加重试上传的回调
 }
 
 // --- BEGIN COMMENT ---
 // 附件预览栏组件
 // --- END COMMENT ---
-export const AttachmentPreviewBar: React.FC<AttachmentPreviewBarProps> = ({ isDark = false, onHeightChange }) => {
+export const AttachmentPreviewBar: React.FC<AttachmentPreviewBarProps> = ({ isDark = false, onHeightChange, onRetryUpload }) => {
   const files = useAttachmentStore((state) => state.files)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -90,7 +91,12 @@ export const AttachmentPreviewBar: React.FC<AttachmentPreviewBarProps> = ({ isDa
       // --- END COMMENT ---*/}
       <div className="px-3 pt-3 pb-2 flex flex-wrap gap-2"> {/* 调整 padding */}
         {files.map((file) => (
-          <AttachmentPreviewItem key={file.id} attachment={file} isDark={isDark} />
+          <AttachmentPreviewItem 
+            key={file.id} 
+            attachment={file} 
+            isDark={isDark} 
+            onRetry={onRetryUpload} 
+          />
         ))}
       </div>
     </div>

--- a/components/chat-input/attachment-preview-item.tsx
+++ b/components/chat-input/attachment-preview-item.tsx
@@ -3,26 +3,22 @@
 import React from "react"
 import { cn, formatBytes } from "@lib/utils"
 import { AttachmentFile, useAttachmentStore } from "@lib/stores/attachment-store"
-import { XIcon, FileTextIcon, AlertCircleIcon, CheckCircle2Icon, UploadCloudIcon } from "lucide-react"
+import { XIcon, FileTextIcon, CheckCircle2Icon, RotateCcw } from "lucide-react"
 import { TooltipWrapper } from "@components/ui/tooltip-wrapper"
+import { Spinner } from "@components/ui/spinner"
 
-// --- BEGIN COMMENT ---
 // 单个附件预览项的 Props 定义
-// --- END COMMENT ---
 interface AttachmentPreviewItemProps {
   attachment: AttachmentFile
   isDark?: boolean
+  onRetry: (id: string) => void
 }
 
-// --- BEGIN COMMENT ---
 // 圆形进度条组件 (无文字)
-// --- END COMMENT ---
 const CircularProgress: React.FC<{ progress: number; size?: number; strokeWidth?: number; isDark?: boolean }> = ({ progress, size = 20, strokeWidth = 2, isDark = false }) => {
   const radius = (size - strokeWidth) / 2
   const circumference = radius * 2 * Math.PI
-  // --- BEGIN COMMENT ---
   // 确保进度在 0-100 之间，防止 offset 计算错误
-  // --- END COMMENT ---
   const safeProgress = Math.max(0, Math.min(100, progress));
   const offset = circumference - (safeProgress / 100) * circumference
 
@@ -56,15 +52,12 @@ const CircularProgress: React.FC<{ progress: number; size?: number; strokeWidth?
         cx={size / 2}
         cy={size / 2}
       />
-      {/* --- REMOVED TEXT ELEMENT --- */}
     </svg>
   )
 }
 
-// --- BEGIN COMMENT ---
 // 单个附件预览项组件 (简约风格 v2)
-// --- END COMMENT ---
-export const AttachmentPreviewItem: React.FC<AttachmentPreviewItemProps> = ({ attachment, isDark = false }) => {
+export const AttachmentPreviewItem: React.FC<AttachmentPreviewItemProps> = ({ attachment, isDark = false, onRetry }) => {
   const removeFile = useAttachmentStore((state) => state.removeFile)
 
   const handleRemove = (e: React.MouseEvent) => {
@@ -72,17 +65,38 @@ export const AttachmentPreviewItem: React.FC<AttachmentPreviewItemProps> = ({ at
     removeFile(attachment.id)
   }
 
+  const handleRetryClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onRetry(attachment.id)
+  }
+
   const StatusIcon = () => {
     switch (attachment.status) {
       case 'uploading':
-        return <CircularProgress progress={attachment.progress} size={18} strokeWidth={2} isDark={isDark} />
+        return <Spinner size="sm" />
       case 'success':
-        return <CheckCircle2Icon className={cn("w-4 h-4", isDark ? "text-gray-400" : "text-gray-500")} />
+        return <CheckCircle2Icon className={cn("w-4 h-4 text-gray-500 dark:text-gray-400")} />
       case 'error':
-        return <AlertCircleIcon className={cn("w-4 h-4", isDark ? "text-red-400" : "text-red-500")} />
+        return (
+          <TooltipWrapper content="重新上传" placement="top" id={`retry-att-${attachment.id}`}>
+            <button 
+              type="button"
+              onClick={handleRetryClick}
+              className={cn(
+                "w-full h-full flex items-center justify-center rounded-full",
+                "text-gray-500 hover:bg-gray-100/50 dark:text-gray-400 dark:hover:bg-gray-900/30",
+                "focus:outline-none focus:ring-1 focus:ring-gray-500 focus:ring-offset-1",
+                "transition-colors duration-150"
+              )}
+              aria-label="重试上传"
+            >
+              <RotateCcw className="w-4 h-4" />
+            </button>
+          </TooltipWrapper>
+        )
       case 'pending':
       default:
-        return <FileTextIcon className={cn("w-4 h-4", isDark ? "text-gray-400" : "text-gray-500")} />
+        return <FileTextIcon className={cn("w-4 h-4 text-gray-500 dark:text-gray-400")} />
     }
   }
 
@@ -93,6 +107,7 @@ export const AttachmentPreviewItem: React.FC<AttachmentPreviewItemProps> = ({ at
         "flex-shrink basis-[calc((100%-1.5rem)/3)] sm:basis-[calc((100%-1rem)/2)]",
         "max-w-[180px] sm:max-w-[200px]",
         isDark ? "bg-gray-700/80 border border-gray-600/60" : "bg-gray-100 border border-gray-200",
+        attachment.status === 'error' && (isDark ? "border-red-500/30" : "border-red-400/30")
       )}
       title={attachment.error ? `错误: ${attachment.error}` : attachment.name}
     >
@@ -135,4 +150,4 @@ export const AttachmentPreviewItem: React.FC<AttachmentPreviewItemProps> = ({ at
       </TooltipWrapper>
     </div>
   )
-} 
+}

--- a/components/chat-input/chat-input.tsx
+++ b/components/chat-input/chat-input.tsx
@@ -161,7 +161,18 @@ export const ChatInput = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey && !isComposing) {
       e.preventDefault();
-      if (!isProcessing) {
+      
+      // --- BEGIN 中文注释 ---
+      // 在回车提交前，进行与按钮禁用逻辑完全一致的检查
+      const shouldBlockSubmit = 
+        isWaiting || // 正在等待响应
+        isProcessing || // 正在处理上一条消息
+        attachments.some(f => f.status === 'uploading') || // 有文件正在上传
+        attachments.some(f => f.status === 'error') || // 有文件上传失败
+        !message.trim(); // 消息为空
+      // --- END 中文注释 ---
+
+      if (!shouldBlockSubmit) {
         handleLocalSubmit();
       }
     }

--- a/components/chat-input/chat-input.tsx
+++ b/components/chat-input/chat-input.tsx
@@ -311,10 +311,16 @@ export const ChatInput = ({
               variant="submit"
               onClick={isWaiting ? undefined : (isProcessing ? onStop : handleLocalSubmit)}
               disabled={
+                // --- BEGIN 中文注释 ---
+                // 1. 等待响应时禁用
                 isWaiting ||
-                isUploadingFiles ||
-                uploadErrorOccurred ||
-                (!isProcessing && !message.trim() && attachments.every(f => f.status === 'success'))
+                // 2. 有文件正在上传时禁用
+                attachments.some(f => f.status === 'uploading') ||
+                // 3. 有文件上传失败时禁用
+                attachments.some(f => f.status === 'error') ||
+                // 4. 没有消息内容时禁用（去除多余判断）
+                (!isProcessing && !message.trim())
+                // --- END 中文注释 ---
               }
               isDark={isDark}
               ariaLabel={isProcessing ? "停止生成" : (isUploadingFiles ? "正在上传..." : (uploadErrorOccurred ? "处理附件错误" : "发送消息"))}

--- a/components/chat/chat-loader.tsx
+++ b/components/chat/chat-loader.tsx
@@ -35,6 +35,7 @@ export const ChatLoader = ({ messages, isWaitingForResponse = false, className }
             <UserMessage 
               key={msg.id} 
               content={msg.text} 
+              attachments={msg.attachments} 
             />
           ) : (
             <AssistantMessage 

--- a/components/chat/messages/file-attachment-display.tsx
+++ b/components/chat/messages/file-attachment-display.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import React from "react"
+import { cn, formatBytes } from "@lib/utils"
+import { useTheme } from "@lib/hooks"
+import { FileTextIcon, FileImageIcon, FileArchiveIcon, FileMusicIcon, FileVideoIcon, FileIcon } from "lucide-react"
+
+export interface MessageAttachment {
+  id: string
+  name: string
+  size: number
+  type: string
+  uploadedId?: string
+}
+
+interface FileAttachmentDisplayProps {
+  attachments: MessageAttachment[]
+  isDark?: boolean
+  className?: string
+}
+
+// 根据MIME类型获取相应图标
+const getFileIcon = (mimeType: string) => {
+  if (mimeType.startsWith('image/')) return FileImageIcon
+  if (mimeType.startsWith('audio/')) return FileMusicIcon
+  if (mimeType.startsWith('video/')) return FileVideoIcon
+  if (mimeType === 'application/pdf' || 
+      mimeType.includes('word') || 
+      mimeType.includes('excel') || 
+      mimeType.includes('csv') || 
+      mimeType.includes('text')) return FileTextIcon
+  if (mimeType.includes('zip') || 
+      mimeType.includes('rar') || 
+      mimeType.includes('tar') || 
+      mimeType.includes('7z') || 
+      mimeType.includes('gzip')) return FileArchiveIcon
+  return FileIcon
+}
+
+export const FileAttachmentDisplay: React.FC<FileAttachmentDisplayProps> = ({ 
+  attachments, 
+  isDark = false, 
+  className
+}) => {
+  if (!attachments || attachments.length === 0) return null
+
+  return (
+    <div
+      className={cn(
+        // 横向排列，右对齐，无右边距
+        "w-full flex flex-wrap gap-2 px-2 pt-2 pb-1 justify-end",
+        className
+      )}
+      style={{
+        maxWidth: '100%',
+        minHeight: '0',
+        marginRight: 0 // 确保无右边距
+      }}
+    >
+      {attachments.map(attachment => {
+        const IconComponent = getFileIcon(attachment.type)
+        return (
+          <div
+            key={attachment.id}
+            className={cn(
+              "relative pl-2 pr-1 py-1 rounded-md flex items-center gap-2 flex-shrink basis-[calc((100%-1.5rem)/3)] sm:basis-[calc((100%-1rem)/2)] max-w-[180px] sm:max-w-[200px]",
+              isDark
+                ? "bg-gray-700/90 border border-gray-600/80 hover:bg-gray-600/90"
+                : "bg-gray-200 border border-gray-400 hover:bg-gray-300",
+              "transition-colors duration-150"
+            )}
+            title={attachment.name}
+          >
+            <div className={cn(
+              "flex-shrink-0 w-5 h-5 flex items-center justify-center relative",
+              isDark ? "text-gray-200" : "text-gray-700"
+            )}>
+              <IconComponent className="w-4 h-4" />
+            </div>
+            <div className="flex-grow min-w-0">
+              <p className={cn(
+                "text-sm font-medium truncate",
+                isDark ? "text-gray-100" : "text-gray-900"
+              )}>{attachment.name}</p>
+              <p className={cn(
+                "text-xs",
+                isDark ? "text-gray-400" : "text-gray-600"
+              )}>{formatBytes(attachment.size)}</p>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+} 

--- a/components/chat/messages/file-attachment-display.tsx
+++ b/components/chat/messages/file-attachment-display.tsx
@@ -4,14 +4,8 @@ import React from "react"
 import { cn, formatBytes } from "@lib/utils"
 import { useTheme } from "@lib/hooks"
 import { FileTextIcon, FileImageIcon, FileArchiveIcon, FileMusicIcon, FileVideoIcon, FileIcon } from "lucide-react"
-
-export interface MessageAttachment {
-  id: string
-  name: string
-  size: number
-  type: string
-  uploadedId?: string
-}
+import { useFilePreviewStore } from "@lib/stores/ui/file-preview-store"
+import type { MessageAttachment } from '@lib/stores/chat-store'
 
 interface FileAttachmentDisplayProps {
   attachments: MessageAttachment[]
@@ -42,34 +36,42 @@ export const FileAttachmentDisplay: React.FC<FileAttachmentDisplayProps> = ({
   isDark = false, 
   className
 }) => {
+  const openPreview = useFilePreviewStore((state) => state.openPreview);
+
   if (!attachments || attachments.length === 0) return null
+
+  const handleAttachmentClick = (attachment: MessageAttachment) => {
+    openPreview(attachment);
+  }
 
   return (
     <div
       className={cn(
-        // 横向排列，右对齐，无右边距
         "w-full flex flex-wrap gap-2 px-2 pt-2 pb-1 justify-end",
         className
       )}
       style={{
         maxWidth: '100%',
         minHeight: '0',
-        marginRight: 0 // 确保无右边距
+        marginRight: 0
       }}
     >
       {attachments.map(attachment => {
         const IconComponent = getFileIcon(attachment.type)
         return (
-          <div
+          <button
             key={attachment.id}
+            onClick={() => handleAttachmentClick(attachment)}
             className={cn(
               "relative pl-2 pr-1 py-1 rounded-md flex items-center gap-2 flex-shrink basis-[calc((100%-1.5rem)/3)] sm:basis-[calc((100%-1rem)/2)] max-w-[180px] sm:max-w-[200px]",
+              "text-left",
               isDark
                 ? "bg-gray-700/90 border border-gray-600/80 hover:bg-gray-600/90"
                 : "bg-gray-200 border border-gray-400 hover:bg-gray-300",
               "transition-colors duration-150"
             )}
-            title={attachment.name}
+            title={`预览 ${attachment.name}`}
+            aria-label={`预览文件 ${attachment.name}`}
           >
             <div className={cn(
               "flex-shrink-0 w-5 h-5 flex items-center justify-center relative",
@@ -87,7 +89,7 @@ export const FileAttachmentDisplay: React.FC<FileAttachmentDisplayProps> = ({
                 isDark ? "text-gray-400" : "text-gray-600"
               )}>{formatBytes(attachment.size)}</p>
             </div>
-          </div>
+          </button>
         )
       })}
     </div>

--- a/components/chat/messages/index.tsx
+++ b/components/chat/messages/index.tsx
@@ -1,4 +1,5 @@
 import { UserMessage } from './user-message';
 import { AssistantMessage } from './assistant-message';
+import { FileAttachmentDisplay } from './file-attachment-display';
 
-export { UserMessage, AssistantMessage }; 
+export { UserMessage, AssistantMessage, FileAttachmentDisplay }; 

--- a/components/chat/messages/user-message.tsx
+++ b/components/chat/messages/user-message.tsx
@@ -2,21 +2,43 @@
 
 import React from "react"
 import { cn } from "@lib/utils"
-import { useTheme } from "@lib/hooks"
+import { useTheme, useMobile } from "@lib/hooks"
+import { MessageAttachment } from '@lib/stores/chat-store'
+import { FileAttachmentDisplay } from './file-attachment-display'
 
 interface UserMessageProps {
   content: string
+  attachments?: MessageAttachment[]
   className?: string
 }
 
-export const UserMessage: React.FC<UserMessageProps> = ({ content, className }) => {
+export const UserMessage: React.FC<UserMessageProps> = ({ content, attachments = [], className }) => {
   const { isDark } = useTheme()
+  const isMobile = useMobile()
+  const hasAttachments = attachments && attachments.length > 0
   
   return (
-    <div className="flex justify-end mb-8">
+    <div className="flex flex-col items-end mb-8 gap-2">
+      {/* 附件显示区域 - 直接右对齐 */}
+      {hasAttachments && (
+        <FileAttachmentDisplay 
+          attachments={attachments.map(att => ({
+            id: att.id,
+            name: att.name,
+            size: att.size,
+            type: att.type,
+            uploadedId: att.upload_file_id
+          }))}
+          isDark={isDark}
+          className={cn(
+            "w-full max-w-[80%] md:max-w-[60%]",
+          )}
+        />
+      )}
+      {/* 消息气泡 */}
       <div
         className={cn(
-          "max-w-[60%] rounded-2xl px-4 py-2",
+          "max-w-[80%] md:max-w-[60%] rounded-2xl px-4 py-2",
           isDark 
             ? "bg-blue-600 text-white" 
             : "bg-blue-500 text-white",

--- a/components/file-preview/file-preview-canvas.tsx
+++ b/components/file-preview/file-preview-canvas.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import React from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { XIcon } from 'lucide-react'
+import { cn, formatBytes } from '@lib/utils'
+import { useFilePreviewStore } from '@lib/stores/ui/file-preview-store'
+import { useTheme } from '@lib/hooks'
+import type { MessageAttachment } from '@lib/stores/chat-store'; // 导入 MessageAttachment 类型
+
+// 文件内容预览组件
+const FileContentViewer: React.FC<{ file: MessageAttachment | null; isDark: boolean }> = ({ file, isDark }) => {
+  if (!file) return null;
+
+  // --- 基础预览实现 ---
+  const filePreviewUrl = `/api/files/preview/${file.upload_file_id}`; // 假设的预览URL
+
+  const renderPreview = () => {
+    if (file.type.startsWith('image/')) {
+      return (
+        <img 
+          src={filePreviewUrl} 
+          alt={file.name} 
+          className="max-w-full h-auto rounded-lg my-4 object-contain" 
+        />
+      );
+    }
+    // TODO: 添加对 PDF, 文本等其他类型的预览支持 (e.g., using iframe or specific libraries)
+    // else if (file.type === 'application/pdf') { ... }
+    // else if (file.type.startsWith('text/')) { ... }
+    else {
+      return (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          (暂不支持预览此文件类型)
+        </p>
+      );
+    }
+  }
+
+  return (
+    <div className={cn("p-4 rounded-lg mt-4", isDark ? "bg-gray-700/70" : "bg-gray-100")}>
+      <h3 className="text-lg font-semibold mb-2">文件详情</h3>
+      <p><strong>名称:</strong> {file.name}</p>
+      <p><strong>类型:</strong> {file.type}</p>
+      <p><strong>大小:</strong> {formatBytes(file.size)}</p>
+      
+      {/* 渲染预览内容 */}
+      {renderPreview()}
+
+      {/* 可选：添加下载按钮 */} 
+      {/* <a 
+        href={filePreviewUrl + '?download=true'} // 添加下载参数 
+        download={file.name} 
+        className="mt-4 inline-block px-3 py-1 rounded bg-blue-500 text-white text-sm hover:bg-blue-600 transition-colors"
+      >
+        下载文件
+      </a> */}
+    </div>
+  );
+};
+
+export const FilePreviewCanvas = () => {
+  const { isPreviewOpen, currentPreviewFile, closePreview } = useFilePreviewStore();
+  const { isDark } = useTheme();
+
+  const panelVariants = {
+    hidden: { x: '100%' },
+    visible: { x: 0 },
+  };
+
+  // 定义与 CSS transition 匹配的动画参数
+  const transitionConfig = {
+    type: "tween",
+    duration: 0.3, // 对应 duration-300
+    ease: "easeInOut" // 尝试匹配 ease-in-out, 可选 'linear', 'easeIn', 'easeOut' 等
+  };
+
+  return (
+    <AnimatePresence>
+      {isPreviewOpen && (
+        <motion.div
+          className={cn(
+            "fixed top-0 right-0 h-full w-[90%] sm:w-[60%] md:w-[50%] lg:w-[40%] z-50 shadow-lg",
+            isDark ? "bg-gray-800 text-gray-100 border-l border-gray-700" : "bg-white text-gray-900 border-l border-gray-200"
+          )}
+          variants={panelVariants}
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+          // 使用 tween 动画并匹配 CSS 过渡参数
+          transition={transitionConfig}
+        >
+          <div className="flex flex-col h-full">
+            {/* 面板头部 */}
+            <div className={cn(
+              "flex items-center justify-between p-4 border-b",
+              isDark ? "border-gray-700" : "border-gray-200"
+            )}>
+              <h2 className="text-xl font-semibold truncate" title={currentPreviewFile?.name}>
+                {currentPreviewFile?.name || '文件预览'}
+              </h2>
+              <button
+                onClick={closePreview}
+                className={cn(
+                  "p-1 rounded-full transition-colors",
+                  isDark ? "hover:bg-gray-700" : "hover:bg-gray-200"
+                )}
+                aria-label="关闭预览"
+              >
+                <XIcon className="w-5 h-5" />
+              </button>
+            </div>
+            {/* 面板内容区 */}
+            <div className="flex-1 overflow-y-auto p-4">
+              <FileContentViewer file={currentPreviewFile} isDark={isDark} />
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}; 

--- a/components/file-preview/file-preview-canvas.tsx
+++ b/components/file-preview/file-preview-canvas.tsx
@@ -6,55 +6,24 @@ import { XIcon } from 'lucide-react'
 import { cn, formatBytes } from '@lib/utils'
 import { useFilePreviewStore } from '@lib/stores/ui/file-preview-store'
 import { useTheme } from '@lib/hooks'
-import type { MessageAttachment } from '@lib/stores/chat-store'; // 导入 MessageAttachment 类型
+import type { MessageAttachment } from '@lib/stores/chat-store';
 
-// 文件内容预览组件
+// 简化版：文件内容预览组件 - 只显示基础信息
 const FileContentViewer: React.FC<{ file: MessageAttachment | null; isDark: boolean }> = ({ file, isDark }) => {
   if (!file) return null;
 
-  // --- 基础预览实现 ---
-  const filePreviewUrl = `/api/files/preview/${file.upload_file_id}`; // 假设的预览URL
-
-  const renderPreview = () => {
-    if (file.type.startsWith('image/')) {
-      return (
-        <img 
-          src={filePreviewUrl} 
-          alt={file.name} 
-          className="max-w-full h-auto rounded-lg my-4 object-contain" 
-        />
-      );
-    }
-    // TODO: 添加对 PDF, 文本等其他类型的预览支持 (e.g., using iframe or specific libraries)
-    // else if (file.type === 'application/pdf') { ... }
-    // else if (file.type.startsWith('text/')) { ... }
-    else {
-      return (
-        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
-          (暂不支持预览此文件类型)
-        </p>
-      );
-    }
-  }
-
   return (
-    <div className={cn("p-4 rounded-lg mt-4", isDark ? "bg-gray-700/70" : "bg-gray-100")}>
-      <h3 className="text-lg font-semibold mb-2">文件详情</h3>
-      <p><strong>名称:</strong> {file.name}</p>
-      <p><strong>类型:</strong> {file.type}</p>
-      <p><strong>大小:</strong> {formatBytes(file.size)}</p>
-      
-      {/* 渲染预览内容 */}
-      {renderPreview()}
-
-      {/* 可选：添加下载按钮 */} 
-      {/* <a 
-        href={filePreviewUrl + '?download=true'} // 添加下载参数 
-        download={file.name} 
-        className="mt-4 inline-block px-3 py-1 rounded bg-blue-500 text-white text-sm hover:bg-blue-600 transition-colors"
-      >
-        下载文件
-      </a> */}
+    // 保留外层容器用于可能的样式调整
+    <div> 
+      <h3 className="text-lg font-semibold mb-4">文件信息</h3>
+      <div className={cn("space-y-1 text-sm", isDark ? "text-gray-300" : "text-gray-700")}>
+        <p><strong>名称:</strong> {file.name}</p>
+        <p><strong>类型:</strong> {file.type}</p>
+        <p><strong>大小:</strong> {formatBytes(file.size)}</p>
+      </div>
+      <p className="mt-6 text-xs text-gray-500 dark:text-gray-400">
+        (文件内容预览功能需后端支持)
+      </p>
     </div>
   );
 };
@@ -68,11 +37,11 @@ export const FilePreviewCanvas = () => {
     visible: { x: 0 },
   };
 
-  // 定义与 CSS transition 匹配的动画参数
+  // 加快动画速度：减少 duration
   const transitionConfig = {
     type: "tween",
-    duration: 0.3, // 对应 duration-300
-    ease: "easeInOut" // 尝试匹配 ease-in-out, 可选 'linear', 'easeIn', 'easeOut' 等
+    duration: 0.2, // 从 0.3 减小到 0.2
+    ease: "easeInOut"
   };
 
   return (
@@ -87,8 +56,7 @@ export const FilePreviewCanvas = () => {
           initial="hidden"
           animate="visible"
           exit="hidden"
-          // 使用 tween 动画并匹配 CSS 过渡参数
-          transition={transitionConfig}
+          transition={transitionConfig} // 应用更快的动画配置
         >
           <div className="flex flex-col h-full">
             {/* 面板头部 */}
@@ -97,7 +65,7 @@ export const FilePreviewCanvas = () => {
               isDark ? "border-gray-700" : "border-gray-200"
             )}>
               <h2 className="text-xl font-semibold truncate" title={currentPreviewFile?.name}>
-                {currentPreviewFile?.name || '文件预览'}
+                {currentPreviewFile?.name || '文件信息'} {/* 标题也改为文件信息 */}
               </h2>
               <button
                 onClick={closePreview}
@@ -112,6 +80,7 @@ export const FilePreviewCanvas = () => {
             </div>
             {/* 面板内容区 */}
             <div className="flex-1 overflow-y-auto p-4">
+              {/* 使用简化版的 FileContentViewer */}
               <FileContentViewer file={currentPreviewFile} isDark={isDark} />
             </div>
           </div>

--- a/components/ui/notification-bar.tsx
+++ b/components/ui/notification-bar.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { AlertTriangleIcon, CheckCircleIcon, InfoIcon, XCircleIcon, XIcon } from 'lucide-react';
+import { cn } from '@lib/utils';
+import { useNotificationStore } from '@lib/stores/ui/notification-store';
+
+const iconMap = {
+  success: CheckCircleIcon,
+  error: XCircleIcon,
+  warning: AlertTriangleIcon,
+  info: InfoIcon,
+};
+
+const colorMap = {
+  success: 'bg-green-500 border-green-600',
+  error: 'bg-red-500 border-red-600',
+  warning: 'bg-yellow-500 border-yellow-600',
+  info: 'bg-blue-500 border-blue-600',
+};
+
+export const NotificationBar: React.FC = () => {
+  const { message, type, isVisible, hideNotification } = useNotificationStore();
+
+  // 如果不可见或没有消息，则不渲染任何内容
+  if (!isVisible || !message) {
+    return null;
+  }
+
+  const IconComponent = iconMap[type] || InfoIcon; // 默认使用 InfoIcon
+  const colors = colorMap[type] || colorMap.info; // 默认使用 info 颜色
+
+  return (
+    <div
+      className={cn(
+        'fixed top-5 left-1/2 transform -translate-x-1/2 z-50', // 定位在顶部居中
+        'w-auto max-w-[90%] md:max-w-md lg:max-w-lg', // 响应式宽度
+        'p-3 rounded-md shadow-lg border text-white flex items-center space-x-3', // 基础样式
+        colors, // 根据类型应用颜色
+        'transition-all duration-300 ease-in-out', // 过渡动画
+        isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4' // 显示/隐藏动画
+      )}
+      role="alert"
+    >
+      <IconComponent className="h-5 w-5 flex-shrink-0" />
+      <span className="flex-grow text-sm font-medium">{message}</span>
+      <button
+        onClick={hideNotification}
+        className="p-1 rounded-full hover:bg-white/20 transition-colors flex-shrink-0"
+        aria-label="关闭通知"
+      >
+        <XIcon className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}; 

--- a/lib/hooks/use-chat-interface.ts
+++ b/lib/hooks/use-chat-interface.ts
@@ -161,6 +161,7 @@ export function useChatInterface() {
         addMessage({ text: `抱歉，请求失败: ${(error as Error).message}`, isUser: false, error: "API 请求失败" });
       }
       setCurrentTaskId(null);
+      throw error;
     }
   }, [
     isProcessing,

--- a/lib/hooks/use-chat-interface.ts
+++ b/lib/hooks/use-chat-interface.ts
@@ -65,7 +65,7 @@ export function useChatInterface() {
   // --- BEGIN COMMENT ---
   // TODO: 获取真实的用户标识符，这里使用占位符
   // --- END COMMENT ---
-  const currentUserIdentifier = "user-placeholder-123"; 
+  const currentUserIdentifier = "userlyz"; 
 
   // --- 处理消息提交 ---
   const handleSubmit = useCallback(async (message: string) => {

--- a/lib/hooks/use-chat-interface.ts
+++ b/lib/hooks/use-chat-interface.ts
@@ -158,7 +158,6 @@ export function useChatInterface() {
         setMessageError(assistantMessageId, `处理消息时发生错误: ${(error as Error).message}`);
       } else {
         setIsWaitingForResponse(false);
-        addMessage({ text: `抱歉，请求失败: ${(error as Error).message}`, isUser: false, error: "API 请求失败" });
       }
       setCurrentTaskId(null);
       throw error;

--- a/lib/hooks/use-chat-interface.ts
+++ b/lib/hooks/use-chat-interface.ts
@@ -76,7 +76,24 @@ export function useChatInterface() {
     }
 
     setIsWaitingForResponse(true);
-    addMessage({ text: message, isUser: true }); // 不传递 files 字段，避免类型错误
+    
+    // 将 files 转换为 MessageAttachment 格式
+    const messageAttachments = Array.isArray(files) && files.length > 0 
+      ? files.map(file => ({
+          id: file.upload_file_id,
+          name: file.name,
+          size: file.size,
+          type: file.mime_type,
+          upload_file_id: file.upload_file_id
+        }))
+      : undefined;
+      
+    // 添加包含附件信息的用户消息
+    addMessage({ 
+      text: message, 
+      isUser: true,
+      attachments: messageAttachments 
+    });
 
     if (isWelcomeScreen) {
       setIsWelcomeScreen(false);

--- a/lib/services/dify/file-service.ts
+++ b/lib/services/dify/file-service.ts
@@ -12,11 +12,12 @@ const DIFY_API_BASE_URL = '/api/dify';
 
 // --- BEGIN COMMENT ---
 /**
- * 上传单个文件到 Dify (通过后端代理)。
+ * 上传单个文件到 Dify (通过后端代理)，支持进度回调。
  *
  * @param appId - Dify 应用的 ID。
  * @param file - 要上传的 File 对象。
  * @param user - Dify 需要的用户标识符。
+ * @param onProgress - 上传进度回调 (0-100)
  * @returns 一个解析为 DifyFileUploadResponse 的 Promise。
  * @throws 如果请求失败或 API 返回错误状态，则抛出错误。
  */
@@ -24,72 +25,67 @@ const DIFY_API_BASE_URL = '/api/dify';
 export async function uploadDifyFile(
   appId: string,
   file: File,
-  user: string
+  user: string,
+  onProgress?: (progress: number) => void
 ): Promise<DifyFileUploadResponse> {
   console.log(`[Dify File Service] Uploading file "${file.name}" for app ${appId}, user ${user}`);
 
-  const slug = 'files/upload'; // Dify API 路径
-  const apiUrl = `${DIFY_API_BASE_URL}/${appId}/${slug}`; // 构造代理 URL
-
   // --- BEGIN COMMENT ---
-  // 创建 FormData 对象
+  // 使用 XMLHttpRequest 以支持上传进度回调
   // --- END COMMENT ---
-  const formData = new FormData();
-  formData.append('file', file); // 'file' 是 Dify API 要求的字段名
-  formData.append('user', user); // 'user' 也是 Dify API 要求的字段名
+  return new Promise((resolve, reject) => {
+    const slug = 'files/upload';
+    const apiUrl = `${DIFY_API_BASE_URL}/${appId}/${slug}`;
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('user', user);
 
-  try {
-    const response = await fetch(apiUrl, {
-      method: 'POST',
-      // --- BEGIN COMMENT ---
-      // 不需要设置 Content-Type，fetch 会自动处理 FormData 的 boundary
-      // 不需要设置 Authorization，代理会处理
-      // --- END COMMENT ---
-      body: formData,
-    });
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', apiUrl, true);
 
-    console.log(`[Dify File Service] Upload response status for "${file.name}":`, response.status);
+    // --- BEGIN COMMENT ---
+    // 监听上传进度
+    // --- END COMMENT ---
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && onProgress) {
+        const percent = Math.round((event.loaded / event.total) * 100);
+        onProgress(percent);
+      }
+    };
 
-    if (!response.ok) {
-      let errorBody = 'Unknown error';
-      let errorCode = 'UNKNOWN';
-      try {
-        // 尝试解析 JSON 错误体
-        const errorJson = await response.json();
-        errorBody = JSON.stringify(errorJson);
-        errorCode = errorJson.code || errorCode; // 尝试获取 Dify 的错误代码
-      } catch (e) {
-        // 如果不是 JSON，尝试读取文本
-        try {
-          errorBody = await response.text();
-        } catch (readErr) {
-          // 忽略读取错误
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === XMLHttpRequest.DONE) {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const result: DifyFileUploadResponse = JSON.parse(xhr.responseText);
+            console.log(`[Dify File Service] File "${file.name}" uploaded successfully. ID: ${result.id}`);
+            resolve(result);
+          } catch (e) {
+            reject(new Error('解析 Dify 文件上传响应失败'));
+          }
+        } else {
+          let errorBody = xhr.responseText || 'Unknown error';
+          let errorCode = 'UNKNOWN';
+          try {
+            const errorJson = JSON.parse(xhr.responseText);
+            errorBody = JSON.stringify(errorJson);
+            errorCode = errorJson.code || errorCode;
+          } catch (e) {}
+          const error = new Error(
+            `Failed to upload file "${file.name}". Status: ${xhr.status}. Code: ${errorCode}. Body: ${errorBody}`
+          );
+          (error as any).code = errorCode;
+          reject(error);
         }
       }
-      // --- BEGIN COMMENT ---
-      // 抛出包含更多信息的错误
-      // --- END COMMENT ---
-      const error = new Error(
-        `Failed to upload file "${file.name}". Status: ${response.status} ${response.statusText}. Code: ${errorCode}. Body: ${errorBody}`
-      );
-      (error as any).code = errorCode; // 将 Dify 错误代码附加到错误对象
-      throw error;
-    }
+    };
 
-    // --- BEGIN COMMENT ---
-    // 解析成功的 JSON 响应体
-    // --- END COMMENT ---
-    const result: DifyFileUploadResponse = await response.json();
-    console.log(`[Dify File Service] File "${file.name}" uploaded successfully. ID: ${result.id}`);
-    return result;
+    xhr.onerror = () => {
+      reject(new Error(`文件上传网络错误: ${xhr.status}`));
+    };
 
-  } catch (error) {
-    console.error(`[Dify File Service] Error uploading file "${file.name}":`, error);
-    // --- BEGIN COMMENT ---
-    // 重新抛出错误，以便上层捕获
-    // --- END COMMENT ---
-    throw error;
-  }
+    xhr.send(formData);
+  });
 }
 
 export {}

--- a/lib/services/dify/file-service.ts
+++ b/lib/services/dify/file-service.ts
@@ -1,0 +1,96 @@
+// --- BEGIN COMMENT ---
+// lib/services/dify/file-service.ts
+// 实现与 Dify 文件上传 API 的交互逻辑。
+// --- END COMMENT ---
+
+import type { DifyFileUploadResponse } from './types';
+
+// --- BEGIN COMMENT ---
+// 指向我们的后端代理 API
+// --- END COMMENT ---
+const DIFY_API_BASE_URL = '/api/dify';
+
+// --- BEGIN COMMENT ---
+/**
+ * 上传单个文件到 Dify (通过后端代理)。
+ *
+ * @param appId - Dify 应用的 ID。
+ * @param file - 要上传的 File 对象。
+ * @param user - Dify 需要的用户标识符。
+ * @returns 一个解析为 DifyFileUploadResponse 的 Promise。
+ * @throws 如果请求失败或 API 返回错误状态，则抛出错误。
+ */
+// --- END COMMENT ---
+export async function uploadDifyFile(
+  appId: string,
+  file: File,
+  user: string
+): Promise<DifyFileUploadResponse> {
+  console.log(`[Dify File Service] Uploading file "${file.name}" for app ${appId}, user ${user}`);
+
+  const slug = 'files/upload'; // Dify API 路径
+  const apiUrl = `${DIFY_API_BASE_URL}/${appId}/${slug}`; // 构造代理 URL
+
+  // --- BEGIN COMMENT ---
+  // 创建 FormData 对象
+  // --- END COMMENT ---
+  const formData = new FormData();
+  formData.append('file', file); // 'file' 是 Dify API 要求的字段名
+  formData.append('user', user); // 'user' 也是 Dify API 要求的字段名
+
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      // --- BEGIN COMMENT ---
+      // 不需要设置 Content-Type，fetch 会自动处理 FormData 的 boundary
+      // 不需要设置 Authorization，代理会处理
+      // --- END COMMENT ---
+      body: formData,
+    });
+
+    console.log(`[Dify File Service] Upload response status for "${file.name}":`, response.status);
+
+    if (!response.ok) {
+      let errorBody = 'Unknown error';
+      let errorCode = 'UNKNOWN';
+      try {
+        // 尝试解析 JSON 错误体
+        const errorJson = await response.json();
+        errorBody = JSON.stringify(errorJson);
+        errorCode = errorJson.code || errorCode; // 尝试获取 Dify 的错误代码
+      } catch (e) {
+        // 如果不是 JSON，尝试读取文本
+        try {
+          errorBody = await response.text();
+        } catch (readErr) {
+          // 忽略读取错误
+        }
+      }
+      // --- BEGIN COMMENT ---
+      // 抛出包含更多信息的错误
+      // --- END COMMENT ---
+      const error = new Error(
+        `Failed to upload file "${file.name}". Status: ${response.status} ${response.statusText}. Code: ${errorCode}. Body: ${errorBody}`
+      );
+      (error as any).code = errorCode; // 将 Dify 错误代码附加到错误对象
+      throw error;
+    }
+
+    // --- BEGIN COMMENT ---
+    // 解析成功的 JSON 响应体
+    // --- END COMMENT ---
+    const result: DifyFileUploadResponse = await response.json();
+    console.log(`[Dify File Service] File "${file.name}" uploaded successfully. ID: ${result.id}`);
+    return result;
+
+  } catch (error) {
+    console.error(`[Dify File Service] Error uploading file "${file.name}":`, error);
+    // --- BEGIN COMMENT ---
+    // 重新抛出错误，以便上层捕获
+    // --- END COMMENT ---
+    throw error;
+  }
+}
+
+export {}
+// 添加一个空的 export {} 确保它被视为一个模块 

--- a/lib/services/dify/types.ts
+++ b/lib/services/dify/types.ts
@@ -260,4 +260,20 @@ export interface DifyStopTaskRequestPayload {
 /** Dify 停止任务响应体 */
 export interface DifyStopTaskResponse {
   result: 'success'; // 固定返回 success
-} 
+}
+
+// --- BEGIN ADDITION ---
+// --- BEGIN COMMENT ---
+// Dify 文件上传 API 响应体
+// POST /files/upload
+// --- END COMMENT ---
+export interface DifyFileUploadResponse {
+  id: string; // 文件 ID (UUID)
+  name: string;
+  size: number;
+  extension: string;
+  mime_type: string;
+  created_by: string | number; // 用户 ID (可能是数字或字符串)
+  created_at: number; // Unix 时间戳
+}
+// --- END ADDITION --- 

--- a/lib/stores/attachment-store.ts
+++ b/lib/stores/attachment-store.ts
@@ -25,6 +25,7 @@ interface AttachmentStoreState {
   updateFileStatus: (id: string, status: AttachmentFile["status"], progress?: number, error?: string) => void
   updateFileUploadedId: (id: string, uploadedId: string) => void
   clearFiles: () => void
+  setFiles: (files: AttachmentFile[]) => void
 }
 
 // --- BEGIN COMMENT ---
@@ -108,4 +109,10 @@ export const useAttachmentStore = create<AttachmentStoreState>((set, get) => ({
   clearFiles: () => {
     set({ files: [] });
   },
+
+  // --- BEGIN ADDITION --- 实现 setFiles ---
+  setFiles: (filesToRestore) => {
+    set({ files: filesToRestore });
+  }
+  // --- END ADDITION ---
 })) 

--- a/lib/stores/attachment-store.ts
+++ b/lib/stores/attachment-store.ts
@@ -4,14 +4,15 @@ import { create } from "zustand"
 // 定义单个附件文件的状态接口
 // --- END COMMENT ---
 export interface AttachmentFile {
-  id: string // 使用文件对象和时间戳等生成的唯一ID
+  id: string // 本地生成的唯一ID
   file: File // 原始 File 对象
   name: string // 文件名
   size: number // 文件大小
-  type: string // 文件类型
+  type: string // 文件类型 (MIME type)
   status: "pending" | "uploading" | "success" | "error" // 上传状态
   progress: number // 上传进度 (0-100)
   error?: string // 错误信息
+  uploadedId?: string // 上传成功后 Dify 返回的文件 ID
 }
 
 // --- BEGIN COMMENT ---
@@ -22,6 +23,7 @@ interface AttachmentStoreState {
   addFiles: (files: File[]) => void
   removeFile: (id: string) => void
   updateFileStatus: (id: string, status: AttachmentFile["status"], progress?: number, error?: string) => void
+  updateFileUploadedId: (id: string, uploadedId: string) => void
   clearFiles: () => void
 }
 
@@ -70,16 +72,35 @@ export const useAttachmentStore = create<AttachmentStoreState>((set, get) => ({
     })
   },
 
-  // --- BEGIN COMMENT ---
-  // 更新指定文件的状态和进度
-  // --- END COMMENT ---
+  // --- BEGIN MODIFICATION ---
+  // 更新指定文件的状态和进度 (可能清除 uploadedId 和 error)
   updateFileStatus: (id, status, progress, error) => {
     set((state) => ({
       files: state.files.map((f) =>
-        f.id === id ? { ...f, status, progress: progress ?? f.progress, error: error ?? f.error } : f
+        f.id === id ? {
+          ...f,
+          status,
+          progress: progress ?? (status === 'uploading' ? 0 : f.progress), // 如果开始上传，重置进度
+          error: error ?? (status !== 'error' ? undefined : f.error), // 清除非错误状态的 error
+          uploadedId: status !== 'success' ? undefined : f.uploadedId // 清除非成功状态的 uploadedId
+         } : f
       ),
     }))
   },
+  // --- END MODIFICATION ---
+
+  // --- BEGIN ADDITION ---
+  // --- BEGIN COMMENT ---
+  // 更新指定文件的 uploadedId (通常在上传成功后调用)
+  // --- END COMMENT ---
+  updateFileUploadedId: (id, uploadedId) => {
+    set((state) => ({
+      files: state.files.map((f) =>
+        f.id === id ? { ...f, uploadedId: uploadedId, status: 'success', progress: 100 } : f
+      ),
+    }))
+  },
+  // --- END ADDITION ---
 
   // --- BEGIN COMMENT ---
   // 清空所有文件，并释放预览 URL

--- a/lib/stores/ui/file-preview-store.ts
+++ b/lib/stores/ui/file-preview-store.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand'
+import type { MessageAttachment } from '@lib/stores/chat-store'
+
+interface FilePreviewState {
+  isPreviewOpen: boolean
+  currentPreviewFile: MessageAttachment | null
+  openPreview: (file: MessageAttachment) => void
+  closePreview: () => void
+}
+
+export const useFilePreviewStore = create<FilePreviewState>((set) => ({
+  isPreviewOpen: false,
+  currentPreviewFile: null,
+  openPreview: (file) => set({ isPreviewOpen: true, currentPreviewFile: file }),
+  closePreview: () => set({ isPreviewOpen: false, currentPreviewFile: null }),
+})) 

--- a/lib/stores/ui/notification-store.ts
+++ b/lib/stores/ui/notification-store.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+
+type NotificationType = 'success' | 'error' | 'warning' | 'info';
+
+interface NotificationState {
+  message: string | null;
+  type: NotificationType;
+  duration: number; // in milliseconds
+  isVisible: boolean;
+  showNotification: (message: string, type?: NotificationType, duration?: number) => void;
+  hideNotification: () => void;
+}
+
+let timeoutId: NodeJS.Timeout | null = null;
+
+export const useNotificationStore = create<NotificationState>((set, get) => ({
+  message: null,
+  type: 'info',
+  duration: 3000,
+  isVisible: false,
+
+  showNotification: (message, type = 'warning', duration = 3000) => {
+    // 如果当前有定时器，先清除，避免快速连续触发导致问题
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    // 设置新的通知状态并显示
+    set({ message, type, duration, isVisible: true });
+    // 设置自动隐藏的定时器
+    timeoutId = setTimeout(() => {
+      get().hideNotification();
+    }, duration);
+  },
+
+  hideNotification: () => {
+    // 清除可能存在的定时器
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+    // 隐藏通知并重置消息
+    set({ isVisible: false, message: null });
+  },
+})); 


### PR DESCRIPTION
待优化和后续工作：
核心 - 实现文件内容预览:
必须创建后端 API 路由（例如 /api/files/preview/[fileId] 或类似）。
该 API 需要能够根据前端传递的 upload_file_id，从 Dify 的实际存储位置（S3、本地等）安全地读取文件内容。
API 需要返回文件内容和正确的 Content-Type。
前端 FileContentViewer 需要完成对不同 Content-Type 的渲染逻辑（PDF、代码、其他文本等）。
实现文件下载功能:
创建类似的后端 API 路由（例如 /api/files/download/[fileId]）。
该 API 除了返回文件内容，还需要设置 Content-Disposition: attachment 响应头。
在 FilePreviewCanvas 中添加一个下载按钮或链接。
完善 Dify App ID 和 User ID 的获取:
替换掉目前写死的 "default" App ID 和 "userlyz" User ID，改为从用户上下文、会话或全局状态中动态获取。
更细致的错误处理和用户反馈:
例如，在预览或下载文件失败时，提供更明确的错误提示。
考虑网络中断等边缘情况。
安全性:
确保后端预览/下载 API 进行了严格的权限校验，防止未授权访问。
(可选) 优化上传服务: 考虑是否需要替换 XHR 为更现代的 Fetch API (虽然 XHR 在此场景下工作良好)。
总的来说，文件上传的前端处理和基础的预览框架已经搭建完成，并且基本遵循了 dify-integration-rule 的规范。最大的缺失是后端对文件内容的读取和传输能力，这是实现完整预览和下载功能的关键瓶颈。