### PR TITLE
refactor(auth): 从 NextAuth 迁移到 Supabase Auth

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -6,13 +6,13 @@
 ┌─────────────────┐      ┌───────────────────┐      ┌─────────────────┐      ┌─────────────┐
 │                 │      │                   │      │                 │      │             │
 │  前端应用层       │──────▶   Next.js API层   │──────▶   服务集成层      │──────▶  数据存储层  │
-│  React + TS     │      │ (含NextAuth.js)   │      │  Dify API       │      │ PostgreSQL  │
-│  Tailwind CSS   │◀─────│ 路由和中间件        │◀─────│  (或其他服务)   │◀─────│ (或其他DB)  │
+│  React + TS     │      │ (含Supabase Auth) │      │  Dify API       │      │ PostgreSQL  │
+│  Tailwind CSS   │◀─────│ 路由和中间件        │◀─────│  (或其他服务)   │◀─────│ (Supabase)  │
 │                 │      │                   │      │                 │      │             │
 └─────────────────┘      └───────────────────┘      └─────────────────┘      └─────────────┘
 ```
 
-LLM-EduHub采用现代化的多层架构设计，结合Next.js App Router的最佳实践，实现前端、API、服务集成和数据存储的无缝衔接。这种分层设计确保了关注点分离，使系统更易于维护和扩展。核心认证服务由 **NextAuth.js** 提供。
+LLM-EduHub采用现代化的多层架构设计，结合Next.js App Router的最佳实践，实现前端、API、服务集成和数据存储的无缝衔接。这种分层设计确保了关注点分离，使系统更易于维护和扩展。核心认证服务由 **Supabase Auth** 提供。
 
 ## 2. 前端架构
 
@@ -22,7 +22,7 @@ LLM-EduHub采用现代化的多层架构设计，结合Next.js App Router的最�
 - **样式方案**: Tailwind CSS
 - **构建工具**: Next.js (App Router)
 - **状态管理**: Zustand
-- **认证库**: NextAuth.js
+- **认证库**: Supabase Auth
 - **工具库**: Lucide Icons, clsx/cn
 
 ### 目录结构设计
@@ -34,7 +34,7 @@ llm-eduhub/
   ├── .vscode/            # VSCode配置文件
   ├── app/                # 应用源代码（App Router模式）
   │   ├── api/            # API路由
-  │   │   ├── auth/       # NextAuth.js 核心认证路由 ([...nextauth])
+  │   │   ├── auth/       # Supabase Auth 相关路由
   │   │   └── dify/       # Dify API集成
   │   │       └── [appId]/[...slug]/ # 动态路由处理
   │   ├── about/          # About页面路由

--- a/components/auth/supabase-auth.tsx
+++ b/components/auth/supabase-auth.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useState } from 'react'
+import { createClient } from '../../lib/supabase/client'
+import { useRouter } from 'next/navigation'
+
+interface AuthFormProps {
+  view?: 'sign_in' | 'sign_up' | 'forgotten_password'
+  redirectTo?: string
+}
+
+/**
+ * Supabase 认证组件
+ * 提供登录、注册和密码重置功能
+ */
+export function SupabaseAuth({ view = 'sign_in', redirectTo = '/' }: AuthFormProps) {
+  const router = useRouter()
+  const supabase = createClient()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const handleSignIn = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    router.push(redirectTo)
+    router.refresh()
+  }
+
+  const handleSignUp = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${window.location.origin}${redirectTo}`,
+      },
+    })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    setMessage('请查看您的邮箱以完成注册')
+    setLoading(false)
+  }
+
+  const handlePasswordReset = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/reset-password`,
+    })
+
+    if (error) {
+      setError(error.message)
+      setLoading(false)
+      return
+    }
+
+    setMessage('密码重置链接已发送到您的邮箱')
+    setLoading(false)
+  }
+
+  return (
+    <div className="w-full max-w-md mx-auto p-6 space-y-6">
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+          {error}
+        </div>
+      )}
+      
+      {message && (
+        <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded">
+          {message}
+        </div>
+      )}
+
+      <form onSubmit={
+        view === 'sign_in' 
+          ? handleSignIn 
+          : view === 'sign_up' 
+            ? handleSignUp 
+            : handlePasswordReset
+      } className="space-y-4">
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+            邮箱
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+          />
+        </div>
+
+        {view !== 'forgotten_password' && (
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              密码
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
+            />
+          </div>
+        )}
+
+        <div>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+          >
+            {loading ? '处理中...' : 
+              view === 'sign_in' 
+                ? '登录' 
+                : view === 'sign_up' 
+                  ? '注册' 
+                  : '重置密码'
+            }
+          </button>
+        </div>
+      </form>
+
+      <div className="text-center text-sm">
+        {view === 'sign_in' && (
+          <>
+            <button 
+              onClick={() => router.push('/register')} 
+              className="text-indigo-600 hover:text-indigo-500"
+            >
+              没有账号？注册
+            </button>
+            <span className="px-2 text-gray-400">|</span>
+            <button 
+              onClick={() => router.push('/forgot-password')} 
+              className="text-indigo-600 hover:text-indigo-500"
+            >
+              忘记密码？
+            </button>
+          </>
+        )}
+        
+        {view === 'sign_up' && (
+          <button 
+            onClick={() => router.push('/login')} 
+            className="text-indigo-600 hover:text-indigo-500"
+          >
+            已有账号？登录
+          </button>
+        )}
+        
+        {view === 'forgotten_password' && (
+          <button 
+            onClick={() => router.push('/login')} 
+            className="text-indigo-600 hover:text-indigo-500"
+          >
+            返回登录
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createBrowserClient } from '@supabase/ssr'
+
+/**
+ * 创建 Supabase 浏览器客户端
+ * 用于客户端组件中访问 Supabase 服务
+ */
+export const createClient = () => {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+}

--- a/lib/supabase/hooks.ts
+++ b/lib/supabase/hooks.ts
@@ -1,0 +1,269 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createClient } from './client'
+import { Session, User } from '@supabase/supabase-js'
+import type { Database } from './types'
+
+/**
+ * 用户认证钩子
+ * 提供用户登录状态和会话信息
+ */
+export const useSupabaseAuth = () => {
+  const supabase = createClient()
+  const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const getSession = async () => {
+      setLoading(true)
+      const { data: { session }, error } = await supabase.auth.getSession()
+      
+      if (error) {
+        console.error('Error fetching session:', error)
+      }
+      
+      setSession(session)
+      setUser(session?.user || null)
+      setLoading(false)
+    }
+
+    getSession()
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setSession(session)
+        setUser(session?.user || null)
+        setLoading(false)
+      }
+    )
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [supabase])
+
+  return { user, session, loading }
+}
+
+/**
+ * 用户资料钩子
+ * 提供用户资料信息和更新方法
+ */
+export const useProfile = () => {
+  const { user } = useSupabaseAuth()
+  const supabase = createClient()
+  const [profile, setProfile] = useState<Database['public']['Tables']['profiles']['Row'] | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const getProfile = async () => {
+      if (!user) {
+        setProfile(null)
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', user.id)
+        .single()
+
+      if (error) {
+        console.error('Error fetching profile:', error)
+      } else {
+        setProfile(data)
+      }
+      
+      setLoading(false)
+    }
+
+    getProfile()
+  }, [user, supabase])
+
+  const updateProfile = useCallback(
+    async (updates: Database['public']['Tables']['profiles']['Update']) => {
+      if (!user) return { error: new Error('No user logged in') }
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .update(updates)
+        .eq('id', user.id)
+        .select()
+        .single()
+
+      if (error) {
+        return { error }
+      }
+
+      setProfile(data)
+      return { data }
+    },
+    [user, supabase]
+  )
+
+  return { profile, loading, updateProfile }
+}
+
+/**
+ * 组织钩子
+ * 提供用户所属组织信息
+ */
+export const useOrganizations = () => {
+  const { user } = useSupabaseAuth()
+  const supabase = createClient()
+  const [organizations, setOrganizations] = useState<Database['public']['Tables']['organizations']['Row'][]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const getOrganizations = async () => {
+      if (!user) {
+        setOrganizations([])
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('organizations')
+        .select(`
+          *,
+          org_members!inner(*)
+        `)
+        .eq('org_members.user_id', user.id)
+
+      if (error) {
+        console.error('Error fetching organizations:', error)
+      } else {
+        setOrganizations(data || [])
+      }
+      
+      setLoading(false)
+    }
+
+    getOrganizations()
+  }, [user, supabase])
+
+  return { organizations, loading }
+}
+
+/**
+ * 对话钩子
+ * 提供用户对话列表
+ */
+export const useConversations = (limit = 10) => {
+  const { user } = useSupabaseAuth()
+  const supabase = createClient()
+  const [conversations, setConversations] = useState<Database['public']['Tables']['conversations']['Row'][]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const getConversations = async () => {
+      if (!user) {
+        setConversations([])
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('conversations')
+        .select('*')
+        .eq('user_id', user.id)
+        .eq('status', 'active')
+        .order('updated_at', { ascending: false })
+        .limit(limit)
+
+      if (error) {
+        console.error('Error fetching conversations:', error)
+      } else {
+        setConversations(data || [])
+      }
+      
+      setLoading(false)
+    }
+
+    getConversations()
+  }, [user, supabase, limit])
+
+  return { conversations, loading }
+}
+
+/**
+ * 消息钩子
+ * 提供特定对话的消息列表和发送消息方法
+ */
+export const useMessages = (conversationId: string | null) => {
+  const supabase = createClient()
+  const [messages, setMessages] = useState<Database['public']['Tables']['messages']['Row'][]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const getMessages = async () => {
+      if (!conversationId) {
+        setMessages([])
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('messages')
+        .select('*')
+        .eq('conversation_id', conversationId)
+        .order('created_at', { ascending: true })
+
+      if (error) {
+        console.error('Error fetching messages:', error)
+      } else {
+        setMessages(data || [])
+      }
+      
+      setLoading(false)
+    }
+
+    getMessages()
+
+    // 设置实时订阅
+    const subscription = supabase
+      .channel(`messages:${conversationId}`)
+      .on('postgres_changes', { 
+        event: 'INSERT', 
+        schema: 'public', 
+        table: 'messages',
+        filter: `conversation_id=eq.${conversationId}`
+      }, (payload) => {
+        setMessages(current => [...current, payload.new as Database['public']['Tables']['messages']['Row']])
+      })
+      .subscribe()
+
+    getMessages()
+
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [conversationId, supabase])
+
+  const sendMessage = useCallback(
+    async (content: string, role: 'user' | 'system' = 'user') => {
+      if (!conversationId) return { error: new Error('No conversation selected') }
+
+      const { data, error } = await supabase
+        .from('messages')
+        .insert({
+          conversation_id: conversationId,
+          role,
+          content,
+          user_id: role === 'user' ? (await supabase.auth.getUser()).data.user?.id : null
+        })
+        .select()
+        .single()
+
+      return { data, error }
+    },
+    [conversationId, supabase]
+  )
+
+  return { messages, loading, sendMessage }
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,30 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+/**
+ * 创建 Supabase 服务器客户端
+ * 用于服务器组件中访问 Supabase 服务
+ * 注意：必须在服务器组件中使用此函数
+ */
+export const createClient = () => {
+  // 使用类型断言来处理 cookies 的类型问题
+  const cookieStore = cookies() as any
+  
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: any) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: any) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    }
+  )
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,0 +1,389 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string
+          full_name: string | null
+          avatar_url: string | null
+          role: 'admin' | 'manager' | 'user'
+          created_at: string
+          updated_at: string
+          last_login: string | null
+          status: 'active' | 'suspended' | 'pending'
+          auth_source: string | null
+          sso_provider_id: string | null
+        }
+        Insert: {
+          id: string
+          full_name?: string | null
+          avatar_url?: string | null
+          role?: 'admin' | 'manager' | 'user'
+          created_at?: string
+          updated_at?: string
+          last_login?: string | null
+          status?: 'active' | 'suspended' | 'pending'
+          auth_source?: string | null
+          sso_provider_id?: string | null
+        }
+        Update: {
+          id?: string
+          full_name?: string | null
+          avatar_url?: string | null
+          role?: 'admin' | 'manager' | 'user'
+          created_at?: string
+          updated_at?: string
+          last_login?: string | null
+          status?: 'active' | 'suspended' | 'pending'
+          auth_source?: string | null
+          sso_provider_id?: string | null
+        }
+      }
+      organizations: {
+        Row: {
+          id: string
+          name: string
+          logo_url: string | null
+          settings: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          logo_url?: string | null
+          settings?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          logo_url?: string | null
+          settings?: Json
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      org_members: {
+        Row: {
+          id: string
+          org_id: string
+          user_id: string
+          role: 'owner' | 'admin' | 'member'
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          org_id: string
+          user_id: string
+          role?: 'owner' | 'admin' | 'member'
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          org_id?: string
+          user_id?: string
+          role?: 'owner' | 'admin' | 'member'
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      ai_configs: {
+        Row: {
+          id: string
+          org_id: string | null
+          provider: string
+          app_id: string | null
+          api_key: string
+          api_url: string
+          settings: Json
+          enabled: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          org_id?: string | null
+          provider: string
+          app_id?: string | null
+          api_key: string
+          api_url: string
+          settings?: Json
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          org_id?: string | null
+          provider?: string
+          app_id?: string | null
+          api_key?: string
+          api_url?: string
+          settings?: Json
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      conversations: {
+        Row: {
+          id: string
+          org_id: string | null
+          user_id: string
+          ai_config_id: string | null
+          title: string
+          summary: string | null
+          settings: Json
+          created_at: string
+          updated_at: string
+          status: string
+        }
+        Insert: {
+          id?: string
+          org_id?: string | null
+          user_id: string
+          ai_config_id?: string | null
+          title: string
+          summary?: string | null
+          settings?: Json
+          created_at?: string
+          updated_at?: string
+          status?: string
+        }
+        Update: {
+          id?: string
+          org_id?: string | null
+          user_id?: string
+          ai_config_id?: string | null
+          title?: string
+          summary?: string | null
+          settings?: Json
+          created_at?: string
+          updated_at?: string
+          status?: string
+        }
+      }
+      messages: {
+        Row: {
+          id: string
+          conversation_id: string
+          user_id: string | null
+          role: 'user' | 'assistant' | 'system'
+          content: string
+          metadata: Json
+          created_at: string
+          status: 'sent' | 'delivered' | 'error'
+        }
+        Insert: {
+          id?: string
+          conversation_id: string
+          user_id?: string | null
+          role: 'user' | 'assistant' | 'system'
+          content: string
+          metadata?: Json
+          created_at?: string
+          status?: 'sent' | 'delivered' | 'error'
+        }
+        Update: {
+          id?: string
+          conversation_id?: string
+          user_id?: string | null
+          role?: 'user' | 'assistant' | 'system'
+          content?: string
+          metadata?: Json
+          created_at?: string
+          status?: 'sent' | 'delivered' | 'error'
+        }
+      }
+      api_logs: {
+        Row: {
+          id: string
+          user_id: string | null
+          conversation_id: string | null
+          provider: string
+          endpoint: string
+          request: Json
+          response: Json
+          status_code: number | null
+          latency_ms: number | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          conversation_id?: string | null
+          provider: string
+          endpoint: string
+          request?: Json
+          response?: Json
+          status_code?: number | null
+          latency_ms?: number | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          conversation_id?: string | null
+          provider?: string
+          endpoint?: string
+          request?: Json
+          response?: Json
+          status_code?: number | null
+          latency_ms?: number | null
+          created_at?: string
+        }
+      }
+      user_preferences: {
+        Row: {
+          id: string
+          user_id: string
+          theme: string
+          language: string
+          notification_settings: Json
+          ai_preferences: Json
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          theme?: string
+          language?: string
+          notification_settings?: Json
+          ai_preferences?: Json
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          theme?: string
+          language?: string
+          notification_settings?: Json
+          ai_preferences?: Json
+          updated_at?: string
+        }
+      }
+      sso_providers: {
+        Row: {
+          id: string
+          name: string
+          protocol: 'SAML' | 'OAuth2' | 'OIDC'
+          settings: Json
+          client_id: string | null
+          client_secret: string | null
+          metadata_url: string | null
+          enabled: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          name: string
+          protocol: 'SAML' | 'OAuth2' | 'OIDC'
+          settings: Json
+          client_id?: string | null
+          client_secret?: string | null
+          metadata_url?: string | null
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          name?: string
+          protocol?: 'SAML' | 'OAuth2' | 'OIDC'
+          settings?: Json
+          client_id?: string | null
+          client_secret?: string | null
+          metadata_url?: string | null
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      domain_sso_mappings: {
+        Row: {
+          id: string
+          domain: string
+          sso_provider_id: string
+          enabled: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          domain: string
+          sso_provider_id: string
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          domain?: string
+          sso_provider_id?: string
+          enabled?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+      }
+      auth_settings: {
+        Row: {
+          id: string
+          allow_email_registration: boolean
+          allow_phone_registration: boolean
+          allow_password_login: boolean
+          require_email_verification: boolean
+          password_policy: Json
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: string
+          allow_email_registration?: boolean
+          allow_phone_registration?: boolean
+          allow_password_login?: boolean
+          require_email_verification?: boolean
+          password_policy?: Json
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: string
+          allow_email_registration?: boolean
+          allow_phone_registration?: boolean
+          allow_password_login?: boolean
+          require_email_verification?: boolean
+          password_policy?: Json
+          created_at?: string
+          updated_at?: string
+        }
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      user_role: 'admin' | 'manager' | 'user'
+      account_status: 'active' | 'suspended' | 'pending'
+      org_member_role: 'owner' | 'admin' | 'member'
+      message_role: 'user' | 'assistant' | 'system'
+      message_status: 'sent' | 'delivered' | 'error'
+      sso_protocol: 'SAML' | 'OAuth2' | 'OIDC'
+    }
+  }
+}


### PR DESCRIPTION
- 恢复中间件中的 Supabase 认证逻辑
- 创建 Supabase 客户端和服务器端集成
- 添加 Supabase 认证组件和 React 钩子
- 更新架构文档，反映认证方式变更

保持现有路由保护逻辑不变，但暂时注释掉以维持当前路由开放状态。
