### PR TITLE
fix(ui): 统一暗黑模式下 Markdown 表格表头样式

### DIFF
--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -237,6 +237,22 @@
   padding: 6px 13px;
 }
 
+/* Apply theme variables to table headers, overriding Tailwind utility classes if necessary */
+/* Light mode (uses variables defined in :root) */
+.markdown-body table th {
+  background-color: var(--md-table-header-bg);
+  color: var(--md-table-header-text);
+  border-bottom-color: var(--md-table-divide); /* Overrides border-gray-700 from Tailwind */
+  /* Spacing and font styles from Tailwind classes like px-4, text-sm will still apply */
+}
+
+/* Dark mode (uses variables defined in .dark) */
+.dark .markdown-body table th {
+  background-color: var(--md-table-header-bg) !important;
+  color: var(--md-table-header-text) !important;
+  border-bottom-color: var(--md-table-divide) !important;
+}
+
 /* LaTeX公式样式 */
 .markdown-body .katex-display {
   overflow-x: auto;


### PR DESCRIPTION
此前，暗黑模式下的 Markdown 表格表头使用 Tailwind 工具类
（例如 `bg-gray-800`, `text-gray-200`）进行样式设置。
这导致其视觉外观与项目中为其他 Markdown 元素（如代码块）
设定的暗黑主题（基于 `stone` 色系）不一致。

此提交更新 'styles/markdown.css' 文件，使表格表头能够应用
项目中定义的 CSS 变量（`--md-table-header-bg`, `--md-table-header-text`,
`--md-table-divide`）。这些变量确保了暗黑模式下表头的背景色、
文本颜色和底部边框颜色现在能够匹配预期的主题（例如，
`stone-900` 背景和 `stone-100` 文本颜色）。

此更改增强了暗黑主题激活时 Markdown 组件间的视觉一致性。
